### PR TITLE
Conversation type and conversation tables added

### DIFF
--- a/Domain/Entities/Conversation.cs
+++ b/Domain/Entities/Conversation.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ChatAll.Domain.Entities
+{
+    public class Conversation
+    { 
+
+        [Key]
+        public int Id { get; set; }
+
+
+        // Number value
+        [Required]
+        public int ConversationTypeId { get; set; }
+
+        // Memory object that's EF Core fill when use include
+        [ForeignKey(nameof(ConversationTypeId))]
+        public ConversationType ConversationType { get; set; } = null!;
+
+        [MaxLength(200)]
+        public string? Title { get; set; }
+
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        
+
+    }
+}

--- a/Domain/Entities/ConversationType.cs
+++ b/Domain/Entities/ConversationType.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ChatAll.Domain.Entities
+{
+    public class ConversationType
+    {
+
+
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+
+        public string? Description { get; set; }
+    }
+}

--- a/Infrastructure/DbData/ChatDb.cs
+++ b/Infrastructure/DbData/ChatDb.cs
@@ -12,6 +12,11 @@ namespace ChatAll.Infraestructure.DbData
 
         // Dbsets represents the tables
         public DbSet<User> Users { get; set; }
+        //public DbSet<Email> Emails { get; set; }
+        public DbSet<ConversationType> ConversationTypes { get; set; }
+
+        public DbSet<Conversation> Conversations { get; set; }
+
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -20,7 +25,18 @@ namespace ChatAll.Infraestructure.DbData
             // Unique email
             modelBuilder.Entity<User>()
                 .HasIndex(u => u.Email)
-                .IsUnique();    
+                .IsUnique();
+
+            // Fk config
+            // Table conversations with a fk to ConversationTypes
+            modelBuilder.Entity<Conversation>()
+                .HasOne(c => c.ConversationType)
+                .WithMany()
+                .HasForeignKey(c => c.ConversationTypeId);
+
+           
+            
+          
         }
     }
 }

--- a/Infrastructure/Migrations/20250820212228_conversation_type_add.Designer.cs
+++ b/Infrastructure/Migrations/20250820212228_conversation_type_add.Designer.cs
@@ -4,6 +4,7 @@ using ChatAll.Infraestructure.DbData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WikiAll.Migrations
 {
     [DbContext(typeof(ChatDb))]
-    partial class WikiDbDataModelSnapshot : ModelSnapshot
+    [Migration("20250820212228_conversation_type_add")]
+    partial class conversation_type_add
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,52 +24,6 @@ namespace WikiAll.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.Conversation", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("ConversationTypeId")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("Title")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ConversationTypeId");
-
-                    b.ToTable("Conversations");
-                });
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.ConversationType", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("ConversationTypes");
-                });
 
             modelBuilder.Entity("ChatAll.Domain.Entities.User", b =>
                 {
@@ -124,17 +81,6 @@ namespace WikiAll.Migrations
                         .IsUnique();
 
                     b.ToTable("Users");
-                });
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.Conversation", b =>
-                {
-                    b.HasOne("ChatAll.Domain.Entities.ConversationType", "ConversationType")
-                        .WithMany()
-                        .HasForeignKey("ConversationTypeId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("ConversationType");
                 });
 #pragma warning restore 612, 618
         }

--- a/Infrastructure/Migrations/20250820212228_conversation_type_add.cs
+++ b/Infrastructure/Migrations/20250820212228_conversation_type_add.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WikiAll.Migrations
+{
+    /// <inheritdoc />
+    public partial class conversation_type_add : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Infrastructure/Migrations/20250820213348_ConversationType.Designer.cs
+++ b/Infrastructure/Migrations/20250820213348_ConversationType.Designer.cs
@@ -4,6 +4,7 @@ using ChatAll.Infraestructure.DbData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WikiAll.Migrations
 {
     [DbContext(typeof(ChatDb))]
-    partial class WikiDbDataModelSnapshot : ModelSnapshot
+    [Migration("20250820213348_ConversationType")]
+    partial class ConversationType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,31 +24,6 @@ namespace WikiAll.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.Conversation", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("ConversationTypeId")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("Title")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ConversationTypeId");
-
-                    b.ToTable("Conversations");
-                });
 
             modelBuilder.Entity("ChatAll.Domain.Entities.ConversationType", b =>
                 {
@@ -124,17 +102,6 @@ namespace WikiAll.Migrations
                         .IsUnique();
 
                     b.ToTable("Users");
-                });
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.Conversation", b =>
-                {
-                    b.HasOne("ChatAll.Domain.Entities.ConversationType", "ConversationType")
-                        .WithMany()
-                        .HasForeignKey("ConversationTypeId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("ConversationType");
                 });
 #pragma warning restore 612, 618
         }

--- a/Infrastructure/Migrations/20250820213348_ConversationType.cs
+++ b/Infrastructure/Migrations/20250820213348_ConversationType.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WikiAll.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConversationType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ConversationTypes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConversationTypes", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ConversationTypes");
+        }
+    }
+}

--- a/Infrastructure/Migrations/20250820220534_ConversationTable.Designer.cs
+++ b/Infrastructure/Migrations/20250820220534_ConversationTable.Designer.cs
@@ -4,6 +4,7 @@ using ChatAll.Infraestructure.DbData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WikiAll.Migrations
 {
     [DbContext(typeof(ChatDb))]
-    partial class WikiDbDataModelSnapshot : ModelSnapshot
+    [Migration("20250820220534_ConversationTable")]
+    partial class ConversationTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -21,31 +24,6 @@ namespace WikiAll.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.Conversation", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("ConversationTypeId")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("Title")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ConversationTypeId");
-
-                    b.ToTable("Conversations");
-                });
 
             modelBuilder.Entity("ChatAll.Domain.Entities.ConversationType", b =>
                 {
@@ -124,17 +102,6 @@ namespace WikiAll.Migrations
                         .IsUnique();
 
                     b.ToTable("Users");
-                });
-
-            modelBuilder.Entity("ChatAll.Domain.Entities.Conversation", b =>
-                {
-                    b.HasOne("ChatAll.Domain.Entities.ConversationType", "ConversationType")
-                        .WithMany()
-                        .HasForeignKey("ConversationTypeId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("ConversationType");
                 });
 #pragma warning restore 612, 618
         }

--- a/Infrastructure/Migrations/20250820220534_ConversationTable.cs
+++ b/Infrastructure/Migrations/20250820220534_ConversationTable.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WikiAll.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConversationTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Infrastructure/Migrations/20250820220800_ConversationsBugDbSet.Designer.cs
+++ b/Infrastructure/Migrations/20250820220800_ConversationsBugDbSet.Designer.cs
@@ -4,6 +4,7 @@ using ChatAll.Infraestructure.DbData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WikiAll.Migrations
 {
     [DbContext(typeof(ChatDb))]
-    partial class WikiDbDataModelSnapshot : ModelSnapshot
+    [Migration("20250820220800_ConversationsBugDbSet")]
+    partial class ConversationsBugDbSet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20250820220800_ConversationsBugDbSet.cs
+++ b/Infrastructure/Migrations/20250820220800_ConversationsBugDbSet.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WikiAll.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConversationsBugDbSet : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Conversations",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ConversationTypeId = table.Column<int>(type: "int", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Conversations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Conversations_ConversationTypes_ConversationTypeId",
+                        column: x => x.ConversationTypeId,
+                        principalTable: "ConversationTypes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Conversations_ConversationTypeId",
+                table: "Conversations",
+                column: "ConversationTypeId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Conversations");
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce ConversationType and Conversation domain entities with EF Core support, configure their relationship in the DbContext, and add corresponding database migrations to create the ConversationTypes and Conversations tables.

New Features:
- Add ConversationType entity with name and description fields
- Add Conversation entity with title, creation timestamp, and foreign key to ConversationType

Enhancements:
- Register ConversationTypes and Conversations DbSet properties in ChatDb
- Configure one-to-many relationship between Conversation and ConversationType
- Add EF Core migrations and update the model snapshot for the new tables