### PR TITLE
New entities for chat logic created

### DIFF
--- a/Domain/Entities/ConversationMember.cs
+++ b/Domain/Entities/ConversationMember.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ChatAll.Domain.Entities
+{
+    public class ConversationMember
+    {
+
+        [Key]
+        public int Id { get; set; }
+
+
+        [Required]
+        public int ConversationId { get; set; }
+
+        // Relation with Conversation
+        [ForeignKey(nameof(ConversationId))]
+        public Conversation Conversation { get; set; } = null!;
+
+        // Relation with user
+        public int UserId { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User User { get; set; } = null!;
+
+
+
+
+
+    }
+}

--- a/Domain/Entities/Message.cs
+++ b/Domain/Entities/Message.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ChatAll.Domain.Entities
+{
+    public class Message
+    {
+
+        [Key]
+        public int Id { get; set; }
+
+        // Relation with conversation
+        [Required]
+        public int ConversationId { get; set; }
+
+        [ForeignKey(nameof(ConversationId))]
+        public Conversation Conversation { get; set; } = null!;
+
+        // Relation with user
+        public int SenderId { get; set; }
+
+        [ForeignKey(nameof(SenderId))]
+        public User Sender { get; set; } = null!;
+
+
+        // Content of the message
+        [MaxLength(2000)]
+        public string? Content { get; set; }
+
+
+
+
+
+    }
+}

--- a/Infrastructure/DbData/ChatDb.cs
+++ b/Infrastructure/DbData/ChatDb.cs
@@ -17,6 +17,11 @@ namespace ChatAll.Infraestructure.DbData
 
         public DbSet<Conversation> Conversations { get; set; }
 
+        public DbSet<ConversationMember> ConversationMembers { get; set; }
+
+        public DbSet<Message> Messages { get; set; }
+
+
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -34,6 +39,25 @@ namespace ChatAll.Infraestructure.DbData
                 .WithMany()
                 .HasForeignKey(c => c.ConversationTypeId);
 
+            modelBuilder.Entity<ConversationMember>()
+                .HasOne(cm => cm.Conversation)
+                .WithMany()
+                .HasForeignKey(cm => cm.ConversationId);
+
+            modelBuilder.Entity<ConversationMember>()
+                .HasOne(cm => cm.User)
+                .WithMany()
+                .HasForeignKey(cm => cm.UserId);
+
+            modelBuilder.Entity<Message>()
+                .HasOne(m => m.Conversation)
+                .WithMany()
+                .HasForeignKey(m => m.ConversationId);
+
+            modelBuilder.Entity<Message>()
+                .HasOne(m => m.Sender)
+                .WithMany()
+                .HasForeignKey(m => m.SenderId);
            
             
           


### PR DESCRIPTION
## Summary by Sourcery

Introduce new chat domain entities and integrate them into EF Core context

New Features:
- Add ConversationMember and Message domain entities with required foreign keys and properties
- Extend ChatDb to include DbSet properties for ConversationMembers and Messages and configure their relationships in OnModelCreating